### PR TITLE
Add models for prompt and generation responses

### DIFF
--- a/core/src/models/generation_status.py
+++ b/core/src/models/generation_status.py
@@ -1,0 +1,7 @@
+from enum import Enum
+
+class GenerationStatus(str, Enum):
+    """An enumeration for the status of a generation job."""
+    PROCESSING = "processing"
+    COMPLETED = "completed"
+    FAILED = "failed"

--- a/core/src/models/prompt_request.py
+++ b/core/src/models/prompt_request.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel, Field
+
+class PromptRequest(BaseModel):
+    """Schema for the initial prompt request."""
+    prompt: str = Field(
+        ...,
+        description="The user's educational prompt."
+    )

--- a/core/src/models/prompt_response.py
+++ b/core/src/models/prompt_response.py
@@ -1,0 +1,9 @@
+import uuid
+from pydantic import BaseModel, Field
+
+class PromptResponse(BaseModel):
+    """Schema for the response after submitting a prompt."""
+    lecture_id: uuid.UUID = Field(
+        ...,
+        description="The unique ID assigned to the generation job."
+    )

--- a/core/src/models/slide_response.py
+++ b/core/src/models/slide_response.py
@@ -1,0 +1,11 @@
+from typing import Optional
+from pydantic import BaseModel, Field, HttpUrl
+from generation_status import GenerationStatus
+
+class SlideResponse(BaseModel):
+    """Schema for the slide generation status and result."""
+    status: GenerationStatus
+    slides_url: Optional[HttpUrl] = Field(
+        default=None,
+        description="The URL to the generated slide deck. Only present if status is 'completed'."
+    )

--- a/core/src/models/video_response.py
+++ b/core/src/models/video_response.py
@@ -1,0 +1,11 @@
+from typing import Optional
+from pydantic import BaseModel, Field, HttpUrl
+from generation_status import GenerationStatus
+
+class VideoResponse(BaseModel):
+    """Schema for the video generation status and result."""
+    status: GenerationStatus
+    video_url: Optional[HttpUrl] = Field(
+        default=None,
+        description="The URL to the generated video. Only present if status is 'completed'."
+    )


### PR DESCRIPTION
Introduces Pydantic models for prompt requests, prompt responses, slide responses, and video responses, along with a GenerationStatus enum. These models define schemas for handling educational prompt submissions and tracking the status and results of slide and video generation jobs.